### PR TITLE
JSON decoding bugfix and other small improvements

### DIFF
--- a/aftership/__init__.py
+++ b/aftership/__init__.py
@@ -5,9 +5,13 @@ import datetime
 import requests
 import dateutil.parser
 import sys
+import logging
 
 
 __author__ = 'AfterShip <support@aftership.com>'
+
+
+logger = logging.getLogger(__name__)
 
 
 # Values for test described in APIv3 class definition below.
@@ -113,6 +117,8 @@ class API(RequestPart):
         elif body:
             params = body
             body = None
+
+        logger.debug('args: %s; url: %s; headers: %s', args, url, headers)
 
         with threading.Lock():
             if self._last_call:

--- a/aftership/__init__.py
+++ b/aftership/__init__.py
@@ -11,6 +11,7 @@ from requests.exceptions import HTTPError
 
 
 __author__ = 'AfterShip <support@aftership.com>'
+__version__ = '0.1'
 
 
 logger = logging.getLogger(__name__)
@@ -102,6 +103,10 @@ class RequestPart(object):
 
 
 class API(RequestPart):
+    DEFAULT_HEADERS = {
+        'User-Agent': 'aftership-python/{}'.format(__version__),
+    }
+
     def __init__(self, key=None,
                  max_calls_per_sec=10,
                  base_url='https://api.aftership.com',
@@ -109,7 +114,8 @@ class API(RequestPart):
         self._last_call = None
         self._rate_limit = 1.0 / float(max_calls_per_sec)
 
-        self._headers = headers
+        self._headers = self.DEFAULT_HEADERS
+        self._headers.update(headers)
         if key:
             self._headers['aftership-api-key'] = key
         self._api_url = '%s/%s' % (base_url, ver)


### PR DESCRIPTION
Sometimes the Aftership API can send an erroneous response which causes a `ValueError` to be thrown. It's preferable for clients to only have to catch an `aftership.APIRequestException`.

Other changes are small tweaks that makes the SDK a bit more useful.